### PR TITLE
Avoid "Undefined index: query" warning

### DIFF
--- a/src/InvoiceNinja/Models/AbstractModel.php
+++ b/src/InvoiceNinja/Models/AbstractModel.php
@@ -154,7 +154,7 @@ class AbstractModel
         ]);
 
         $parsedUrl = parse_url($url);
-        $separator = ($parsedUrl['query'] == NULL) ? '?' : '&';
+        $separator = (!isset($parsedUrl['query']) || $parsedUrl['query'] == NULL) ? '?' : '&';
 
         $url .= $separator . http_build_query($options);
 


### PR DESCRIPTION
When the `$parsedUrl` array does not contain the `query` key (which is not always the case) an `ErrorException` occurs.

The following code is a minimal working example which raises the exception (using Laravel 5):

```php
use InvoiceNinja\Config as NinjaConfig;
use InvoiceNinja\Models\Invoice;

NinjaConfig::setURL('https://my.host.com/api/v1');
NinjaConfig::setToken('api-token);

$invoice = Invoice::find(1);
```

By adding the `isset` check the exception can be avoided.