### PR TITLE
Add statics

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,33 @@ Convert posted data to a model
     $client = Client::hydrate($input);
 
 *Currently supported for clients, invoices, quotes and payments*
+
+## Statics
+
+*Retrieve the static dataset Invoice Ninja uses*
+
+Get all statics
+
+    Statics::all();
+
+Get specific static
+
+    Statics::countries();
+
+List of available statics
+
+    Statics::currencies();
+    Statics::sizes();
+    Statics::timezones();
+    Statics::dateFormats();
+    Statics::datetimeFormats();
+    Statics::languages();
+    Statics::paymentTerms();
+    Statics::paymentTypes();
+    Statics::countries();
+    Statics::invoiceDesigns();
+    Statics::invoiceStatus();
+    Statics::frequencies();
+    Statics::gateways();
+    Statics::fonts();
+    Statics::banks();

--- a/src/InvoiceNinja/Models/Statics.php
+++ b/src/InvoiceNinja/Models/Statics.php
@@ -1,0 +1,95 @@
+<?php namespace InvoiceNinja\Models;
+
+use stdClass;
+
+class Statics extends AbstractModel
+{
+    public static $route = 'static';
+
+    public static function all()
+    {
+        $url = static::getRoute() . '/';
+        
+        return static::sendRequest($url, false, 'GET', true);
+    }
+
+    public static function get($static)
+    {
+        return json_decode(static::all(), true)['data'][$static];
+    }
+
+    public static function countries()
+    {
+        return static::get('countries');
+    }
+
+    public static function currencies()
+    {
+        return static::get('currencies');
+    }
+
+    public static function sizes()
+    {
+        return static::get('sizes');
+    }
+
+    public static function industries()
+    {
+        return static::get('industries');
+    }
+
+    public static function timezones()
+    {
+        return static::get('timezones');
+    }
+
+    public static function dateFormats()
+    {
+        return static::get('dateFormats');
+    }
+
+    public static function datetimeFormats()
+    {
+        return static::get('datetimeFormats');
+    }
+
+    public static function languages()
+    {
+        return static::get('languages');
+    }
+
+    public static function paymentTerms()
+    {
+        return static::get('paymentTypes');
+    }
+
+    public static function invoiceDesigns()
+    {
+        return static::get('invoiceDesigns');
+    }
+
+    public static function invoiceStatus()
+    {
+        return static::get('invoiceStatus');
+    }
+
+    public static function frequencies()
+    {
+        return static::get('frequencies');
+    }
+
+    public static function gateways()
+    {
+        return static::get('gateways');
+    }
+
+    public static function fonts()
+    {
+        return static::get('fonts');
+    }
+
+    public static function banks()
+    {
+        return static::get('banks');
+    }
+}


### PR DESCRIPTION
As noted in https://github.com/invoiceninja/invoiceninja/issues/982, in order to fully integrated Invoice Ninja with other systems it is very important to have direct access to statics using API. This is only a simple wrapper to use the API to retrieve the static dataset with the following endpoint `api/v1/static`.