### PR TITLE
Update Invoice.php

### DIFF
--- a/src/InvoiceNinja/Models/Invoice.php
+++ b/src/InvoiceNinja/Models/Invoice.php
@@ -29,7 +29,7 @@ class Invoice extends AbstractModel
     public function download()
     {
         $url = static::getRoute() . '/' . $this->id;
-        $url = str_replace('invoices', 'download', $url);
+        $url = str_replace('/invoices/', '/download/', $url);
         
         return static::sendRequest($url, false, 'GET', true);
     }


### PR DESCRIPTION
If you're using InvoiceNinja on a "invoices." subdomain, this str_replace is replacing the API url by "download.domain.com".

I added "/" before and after "invoices" in order to just replace the endpoint "/api/v1/invoices/" by "/api/v1/download/".