### PR TITLE
Add phone to client contact

### DIFF
--- a/src/InvoiceNinja/Models/AbstractModel.php
+++ b/src/InvoiceNinja/Models/AbstractModel.php
@@ -12,6 +12,17 @@ class AbstractModel
     public $id;
 
     /**
+     * Create method to bypass models constructors
+     * @return AbstractModel
+     * @throws \ReflectionException
+     */
+    public static function create()
+    {
+        $rc = new \ReflectionClass(get_called_class());
+        return $rc->newInstanceWithoutConstructor();
+    }
+
+    /**
     * @return array
     */
     public static function all()

--- a/src/InvoiceNinja/Models/Client.php
+++ b/src/InvoiceNinja/Models/Client.php
@@ -13,12 +13,13 @@ class Client extends AbstractModel
         $this->addContact($email, $first_name, $last_name);
     }
 
-    public function addContact($email = '', $first_name = '', $last_name = '')
+    public function addContact($email = '', $first_name = '', $last_name = '', $phone = '')
     {
         $contact = new stdClass();
         $contact->email = $email;
         $contact->first_name = $first_name;
         $contact->last_name = $last_name;
+        $contact->phone = $phone;
 
         $this->contacts[] = $contact;
     }


### PR DESCRIPTION
**Purpose**
I wanted to create a client, but I had no way to add phone number on client contact, except the way to override Client model

**Goal**
Be able to call method create() on models
```php
$client = Client::create();
$client->name = 'Client name';
$client->addContact('humbert.julien54@gmail.com', 'Julien', 'HUMBERT', 'Phone number');
$client->save();
```

**Changes**
Static create method on AbstractModel to bypass models constructors
Add phone on client contact method