### PR TITLE
Added `convert` method to AbstractModel class.

### DIFF
--- a/src/InvoiceNinja/Models/AbstractModel.php
+++ b/src/InvoiceNinja/Models/AbstractModel.php
@@ -141,6 +141,11 @@ class AbstractModel
     {
         return $this->sendAction('delete');
     }
+    
+    public function convert()
+    {
+        return $this->sendAction('convert');
+    }
 
     public static function subscribeCreate($target)
     {


### PR DESCRIPTION
I noticed that the SDK has the ability, in the `InvoiceAPIController` controller, to convert a Quote to an Invoice. However, I could not find a way to call it from the SDK, and so I added the function. Alternatively, I would add something like this:

    public function action($action)
    {
        return $this->sendAction($action);
    }

Where `action` could be anything so that a user is able to call any given action (future proof). An exception handler can be created in the case that the InvoiceNinja API does not recognize an action.