### PR TITLE
Added convert method to Invoice class

### DIFF
--- a/src/InvoiceNinja/Models/Invoice.php
+++ b/src/InvoiceNinja/Models/Invoice.php
@@ -33,4 +33,9 @@ class Invoice extends AbstractModel
         
         return static::sendRequest($url, false, 'GET', true);
     }
+
+    public function convert() 
+    {
+        return $this->sendAction('convert');
+    }
 }


### PR DESCRIPTION
I noticed that the SDK has the ability, in the `InvoiceAPIController` controller, to convert a Quote to an Invoice. However, I could not find a way to call it from the SDK, and so I added the function.