### PR TITLE
Send function in Invoice Model class should return a raw response

### DIFF
--- a/src/InvoiceNinja/Models/Invoice.php
+++ b/src/InvoiceNinja/Models/Invoice.php
@@ -44,6 +44,6 @@ class Invoice extends AbstractModel
         $url = static::getRoute();
         $url = str_replace('/invoices/', '/email_invoice/', $url);
 
-        return static::sendRequest($url, ['id' => $this->id], 'POST', false);
+        return static::sendRequest($url, ['id' => $this->id], 'POST', true);
     }
 }


### PR DESCRIPTION
The response from the `send` function in `Invoice.php` is like:

    { 
        "message": success
    }

And can therefore not be created into a new Model. There fore the called `sendRequest` method should be called with the flag `raw` set to `true`.