### PR TITLE
Refactor tests to use phpunit.xml env variables for invoiceninja url & token

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -11,5 +11,7 @@
     </testsuite>
   </testsuites>
   <php>
-    </php>
+    <env name="INVOICENINJA_TOKEN" value="company-token-test"/>
+    <env name="INVOICENINJA_URL" value="http://ninja.test:8000"/>
+  </php>
 </phpunit>

--- a/tests/BankIntegrationsTest.php
+++ b/tests/BankIntegrationsTest.php
@@ -16,9 +16,6 @@ use PHPUnit\Framework\TestCase;
 
 class BankIntegrationsTest extends TestCase
 {
-    protected string $token = "company-token-test";
-    protected string $url = "http://ninja.test:8000";
-
 
 
     public function setUp() :void
@@ -29,8 +26,8 @@ class BankIntegrationsTest extends TestCase
 
     public function testBankIntegrations()
     {
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $bank_integrations = $ninja->bank_integrations->create(['bank_account_name' => $this->faker->firstName]);
 
@@ -41,15 +38,15 @@ class BankIntegrationsTest extends TestCase
     public function testBankIntegrationGet()
     {
     
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $integration = $ninja->bank_integrations->create(['bank_account_name' => $this->faker->firstName]);
         
         $this->assertTrue(is_array($integration));
 
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $bank_integrations = $ninja->bank_integrations->get($integration['data']['id']);
 
@@ -61,8 +58,8 @@ class BankIntegrationsTest extends TestCase
     public function testBankIntegrationPut()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $integration = $ninja->bank_integrations->create(['bank_account_name' => $this->faker->firstName]);
 
@@ -76,8 +73,8 @@ class BankIntegrationsTest extends TestCase
     public function testBankIntegrationPost()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $bank_integrations = $ninja->bank_integrations->create(['bank_account_name' => $this->faker->firstName]);
         

--- a/tests/BankTransactionsTest.php
+++ b/tests/BankTransactionsTest.php
@@ -16,9 +16,6 @@ use PHPUnit\Framework\TestCase;
 
 class BankTransactionsTest extends TestCase
 {
-    protected string $token = "company-token-test";
-    protected string $url = "http://ninja.test:8000";
-
 
 
     public function setUp() :void
@@ -29,8 +26,8 @@ class BankTransactionsTest extends TestCase
 
     public function testBankTransactions()
     {
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $bank_integrations = $ninja->bank_integrations->create(['bank_account_name' => $this->faker->firstName]);
 
@@ -43,8 +40,8 @@ class BankTransactionsTest extends TestCase
     public function testTransactionGet()
     {
     
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $bank_integrations = $ninja->bank_integrations->create(['bank_account_name' => $this->faker->firstName]);
 
@@ -52,8 +49,8 @@ class BankTransactionsTest extends TestCase
         
         $this->assertTrue(is_array($transaction));
 
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $transactions = $ninja->bank_transactions->get($transaction['data']['id']);
 
@@ -65,8 +62,8 @@ class BankTransactionsTest extends TestCase
     public function testTransactionPut()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $bank_integrations = $ninja->bank_integrations->create(['bank_account_name' => $this->faker->firstName]);
 
@@ -82,8 +79,8 @@ class BankTransactionsTest extends TestCase
     public function testTransactionPost()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $bank_integrations = $ninja->bank_integrations->create(['bank_account_name' => $this->faker->firstName]);
 

--- a/tests/BulkActionsTest.php
+++ b/tests/BulkActionsTest.php
@@ -16,14 +16,11 @@ use PHPUnit\Framework\TestCase;
 
 class BulkActionsTest extends TestCase
 {
-    protected string $token = "company-token-test";
-    protected string $url = "http://ninja.test:8000";
-
     public function testArchive()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $client = $ninja->clients->create(['name' => 'A name']);
 

--- a/tests/ClientsTest.php
+++ b/tests/ClientsTest.php
@@ -16,13 +16,13 @@ use PHPUnit\Framework\TestCase;
 
 class ClientsTest extends TestCase
 {
-    protected string $token = "company-token-test";
-    protected string $url = "http://ninja.test:8000";
+
+
 
     public function testClients()
     {
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $clients = $ninja->clients->create(['name' => 'Brand spanking new client']);
         
@@ -37,15 +37,15 @@ class ClientsTest extends TestCase
     public function testClientGet()
     {
     
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $client = $ninja->clients->create(['name' => 'Brand spanking new client']);
         
         $this->assertTrue(is_array($client));
 
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $clients = $ninja->clients->get($client['data']['id']);
 
@@ -57,8 +57,8 @@ class ClientsTest extends TestCase
     public function testClientPut()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $client = $ninja->clients->create(['name' => 'Brand spanking new client']);
 
@@ -185,8 +185,8 @@ class ClientsTest extends TestCase
             ]
         ];
 
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $client = $ninja->clients->create($create);
 
@@ -205,8 +205,8 @@ class ClientsTest extends TestCase
     public function testClientPost()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $clients = $ninja->clients->create(['name' => 'Brand spanking new client']);
         
@@ -218,8 +218,8 @@ class ClientsTest extends TestCase
     public function testClientWithContactPost()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $clients = $ninja->clients->create([
             'name' => 'Brand spanking new client',

--- a/tests/CompaniesTest.php
+++ b/tests/CompaniesTest.php
@@ -16,14 +16,11 @@ use PHPUnit\Framework\TestCase;
 
 class CompaniesTest extends TestCase
 {
-    protected string $token = "company-token-test";
-    protected string $url = "http://ninja.test:8000";
-
     public function testCompanies()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $companies = $ninja->companies->all();
 
@@ -34,8 +31,8 @@ class CompaniesTest extends TestCase
     public function testCompanyGet()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $company = $ninja->companies->create([], ['include' => 'company,company.tokens']);
         $token = $company['data'][0]['company']['tokens'][0]['token'];
@@ -51,8 +48,8 @@ class CompaniesTest extends TestCase
     public function testCompanyPut()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $company = $ninja->companies->create([], ['include' => 'company,company.tokens']);
         $token = $company['data'][0]['company']['tokens'][0]['token'];
@@ -68,8 +65,8 @@ class CompaniesTest extends TestCase
     public function testCompanyPost()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $companies = $ninja->companies->create([], ['include' => 'company']);
 

--- a/tests/CreditsTest.php
+++ b/tests/CreditsTest.php
@@ -16,14 +16,11 @@ use PHPUnit\Framework\TestCase;
 
 class CreditsTest extends TestCase
 {
-    protected string $token = "company-token-test";
-    protected string $url = "http://ninja.test:8000";
-
     public function testCredits()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $client = $ninja->clients->create(['name' => 'Brand spanking new client']);
 
@@ -38,8 +35,8 @@ class CreditsTest extends TestCase
     public function testCreditGet()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $client = $ninja->clients->create(['name' => 'Brand spanking new client']);
 
@@ -55,8 +52,8 @@ class CreditsTest extends TestCase
     public function testCreditPut()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $client = $ninja->clients->create(['name' => 'Brand spanking new client']);
 
@@ -72,8 +69,8 @@ class CreditsTest extends TestCase
     public function testCreditPost()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $client = $ninja->clients->create(['name' => 'Brand spanking new client']);
 

--- a/tests/ExpenseCategoriesTest.php
+++ b/tests/ExpenseCategoriesTest.php
@@ -16,9 +16,6 @@ use PHPUnit\Framework\TestCase;
 
 class ExpenseCategoriesTest extends TestCase
 {
-    protected string $token = "company-token-test";
-    protected string $url = "http://ninja.test:8000";
-
 
     public function setUp() :void
     {
@@ -29,8 +26,8 @@ class ExpenseCategoriesTest extends TestCase
 
     public function testExpenseCategoriesPost()
     {
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $expense_categories = $ninja->expense_categories->create(['name' => $this->faker->text(10)]);
         
@@ -45,15 +42,15 @@ class ExpenseCategoriesTest extends TestCase
     public function testExpenseCategoryGet()
     {
     
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $expense_categories = $ninja->expense_categories->create(['name' => $this->faker->text(10)]);
         
         $this->assertTrue(is_array($expense_categories));
 
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $expense_categories = $ninja->expense_categories->get($expense_categories['data']['id']);
 
@@ -65,8 +62,8 @@ class ExpenseCategoriesTest extends TestCase
     public function testExpenseCategoryPut()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $expense_category = $this->faker->text(10);
         
@@ -82,8 +79,8 @@ class ExpenseCategoriesTest extends TestCase
     public function testExpenseCategoryPost()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $expense_categories = $ninja->expense_categories->create(['name' => $this->faker->firstName]);
         

--- a/tests/ExpensesTest.php
+++ b/tests/ExpensesTest.php
@@ -16,14 +16,11 @@ use PHPUnit\Framework\TestCase;
 
 class ExpensesTest extends TestCase
 {
-    protected string $token = "company-token-test";
-    protected string $url = "http://ninja.test:8000";
-
     public function testExpenses()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $expenses = $ninja->expenses->all();
 
@@ -34,8 +31,8 @@ class ExpensesTest extends TestCase
     public function testExpenseGet()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $client = $ninja->clients->create(['name' => 'Brand spanking new clients']);
         $expense = $ninja->expenses->create(['client_id' => $client['data']['id']]);
@@ -50,8 +47,8 @@ class ExpensesTest extends TestCase
     public function testExpensePut()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
 
         $clients = $ninja->clients->create(['name' => 'Brand spanking new client']);
@@ -67,8 +64,8 @@ class ExpensesTest extends TestCase
     public function testExpensePost()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
         $client = $ninja->clients->create(['name' => 'Brand spanking new client']);
 
         $expenses = $ninja->expenses->create(['client_id' => $client['data']['id']]);

--- a/tests/GroupSettingsTest.php
+++ b/tests/GroupSettingsTest.php
@@ -16,10 +16,6 @@ use PHPUnit\Framework\TestCase;
 
 class GroupSettingsTest extends TestCase
 {
-    protected string $token = "company-token-test";
-    protected string $url = "http://ninja.test:8000";
-
-
     public function setUp() :void
     {
         parent::setUp();
@@ -29,8 +25,8 @@ class GroupSettingsTest extends TestCase
 
     public function testAddGroupSetting()
     {
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $settings = new \stdClass;
         $settings->currency_id = '1';
@@ -48,8 +44,8 @@ class GroupSettingsTest extends TestCase
 
     public function testUpdateGroupSetting()
     {
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $settings = new \stdClass;
         $settings->currency_id = '1';

--- a/tests/Invoice/CreateInvoiceTest.php
+++ b/tests/Invoice/CreateInvoiceTest.php
@@ -19,17 +19,14 @@ use PHPUnit\Framework\TestCase;
 
 class CreateInvoiceTest extends TestCase
 {
-    protected string $token = "company-token-test";
-    protected string $url = "http://ninja.test:8000";
-
     public function setUp() :void
     {
         parent::setUp();
         $this->faker = \Faker\Factory::create();
     }
 
-    // $ninja = new InvoiceNinja($this->token);
-    // $ninja->setUrl($this->url);
+    // $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+    // $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
     public function testInitInvoice()
     {

--- a/tests/InvoicesTest.php
+++ b/tests/InvoicesTest.php
@@ -16,14 +16,11 @@ use PHPUnit\Framework\TestCase;
 
 class InvoicesTest extends TestCase
 {
-    protected string $token = "company-token-test";
-    protected string $url = "http://ninja.test:8000";
-
     public function testInvoices()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $client = $ninja->clients->create(['name' => 'Brand spanking new client']);
 
@@ -38,8 +35,8 @@ class InvoicesTest extends TestCase
     public function testInvoiceGet()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $client = $ninja->clients->create(['name' => 'Brand spanking new client']);
 
@@ -55,8 +52,8 @@ class InvoicesTest extends TestCase
     public function testInvoicePut()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $client = $ninja->clients->create(['name' => 'Brand spanking new client']);
 
@@ -72,8 +69,8 @@ class InvoicesTest extends TestCase
     public function testInvoicePost()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $client = $ninja->clients->create(['name' => 'Brand spanking new client']);
 
@@ -87,8 +84,8 @@ class InvoicesTest extends TestCase
     public function testInvoicePostWithItems()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $client = $ninja->clients->create(['name' => 'Brand spanking new client']);
 
@@ -115,8 +112,8 @@ class InvoicesTest extends TestCase
     public function testInvoicePostWithMultiItems()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $client = $ninja->clients->create(['name' => 'Brand spanking new client']);
 
@@ -149,8 +146,8 @@ class InvoicesTest extends TestCase
     public function testInvoicePostWithMultiItemsMarkSent()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $client = $ninja->clients->create(['name' => 'Brand spanking new client']);
 
@@ -184,8 +181,8 @@ class InvoicesTest extends TestCase
     public function testDownloadInvoice()
     {
 
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $client = $ninja->clients->create(['name' => 'Brand spanking new client']);
 

--- a/tests/PaymentsTest.php
+++ b/tests/PaymentsTest.php
@@ -16,14 +16,11 @@ use PHPUnit\Framework\TestCase;
 
 class PaymentsTest extends TestCase
 {
-    protected string $token = "company-token-test";
-    protected string $url = "http://ninja.test:8000";
-
     public function testPayments()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $payments = $ninja->payments->all();
 
@@ -34,8 +31,8 @@ class PaymentsTest extends TestCase
     public function testInvoiceGet()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $client = $ninja->clients->create(['name' => 'Brand spanking new client']);
         $payment = $ninja->payments->create(['client_id' => $client['data']['id'], 'amount' => 10]);
@@ -50,8 +47,8 @@ class PaymentsTest extends TestCase
     public function testInvoicePut()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $client = $ninja->clients->create(['name' => 'Brand spanking new client']);
         $payment = $ninja->payments->create(['client_id' => $client['data']['id'], 'amount' => 10]);
@@ -66,8 +63,8 @@ class PaymentsTest extends TestCase
     public function testInvoicePost()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $client = $ninja->clients->create(['name' => 'Brand spanking new client']);
 
@@ -80,8 +77,8 @@ class PaymentsTest extends TestCase
     public function testInvoicePostPaymentWithInvoicePayment()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $client = $ninja->clients->create(['name' => 'Brand spanking new client']);
 
@@ -117,8 +114,8 @@ class PaymentsTest extends TestCase
     public function testInvoicePostPaymentWithInvoicePaymentAndTransactionReference()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $client = $ninja->clients->create(['name' => 'Brand spanking new client']);
 

--- a/tests/ProductsTest.php
+++ b/tests/ProductsTest.php
@@ -16,14 +16,11 @@ use PHPUnit\Framework\TestCase;
 
 class ProductsTest extends TestCase
 {
-    protected string $token = "company-token-test";
-    protected string $url = "http://ninja.test:8000";
-
     public function testProducts()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $products = $ninja->products->all();
 
@@ -34,8 +31,8 @@ class ProductsTest extends TestCase
     public function testInvoiceGet()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $product = $ninja->products->create(['product_key' => 'that']);
 
@@ -49,8 +46,8 @@ class ProductsTest extends TestCase
     public function testInvoicePut()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $product = $ninja->products->create(['product_key' => 'thatx']);
 
@@ -64,8 +61,8 @@ class ProductsTest extends TestCase
     public function testInvoicePost()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $products = $ninja->products->create(['product_key' => 'that']);
         

--- a/tests/ProjectsTest.php
+++ b/tests/ProjectsTest.php
@@ -16,14 +16,11 @@ use PHPUnit\Framework\TestCase;
 
 class ProjectsTest extends TestCase
 {
-    protected string $token = "company-token-test";
-    protected string $url = "http://ninja.test:8000";
-
     public function testProjects()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $projects = $ninja->projects->all();
 
@@ -34,8 +31,8 @@ class ProjectsTest extends TestCase
     public function testProjectGet()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $client = $ninja->clients->create(['name' => 'Brand spanking new client']);
         $product = $ninja->projects->create(['name' => 'Project', 'client_id' => $client['data']['id']]);
@@ -50,8 +47,8 @@ class ProjectsTest extends TestCase
     public function testProjectPut()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $client = $ninja->clients->create(['name' => 'Brand spanking new client']);
         $product = $ninja->projects->create(['name' => 'Project', 'client_id' => $client['data']['id']]);
@@ -66,8 +63,8 @@ class ProjectsTest extends TestCase
     public function testProjectPost()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $client = $ninja->clients->create(['name' => 'Brand spanking new client']);
         $projects = $ninja->projects->create(['name' => 'Project', 'client_id' => $client['data']['id']]);        

--- a/tests/PurchaseOrdersTest.php
+++ b/tests/PurchaseOrdersTest.php
@@ -16,14 +16,11 @@ use PHPUnit\Framework\TestCase;
 
 class PurchaseOrdersTest extends TestCase
 {
-    protected string $token = "company-token-test";
-    protected string $url = "http://ninja.test:8000";
-
     public function testPurchaseOrders()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $client = $ninja->vendors->create(['name' => 'Brand spanking new client']);
 
@@ -38,8 +35,8 @@ class PurchaseOrdersTest extends TestCase
     public function testPurchaseOrderGet()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $client = $ninja->vendors->create(['name' => 'Brand spanking new client']);
 
@@ -55,8 +52,8 @@ class PurchaseOrdersTest extends TestCase
     public function testPurchaseOrderPut()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $client = $ninja->vendors->create(['name' => 'Brand spanking new client']);
 
@@ -72,8 +69,8 @@ class PurchaseOrdersTest extends TestCase
     public function testPurchaseOrderPost()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $client = $ninja->vendors->create(['name' => 'Brand spanking new client']);
 
@@ -87,8 +84,8 @@ class PurchaseOrdersTest extends TestCase
     public function testPurchaseOrderPostWithItems()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $client = $ninja->vendors->create(['name' => 'Brand spanking new client']);
 
@@ -115,8 +112,8 @@ class PurchaseOrdersTest extends TestCase
     public function testPurchaseOrderPostWithMultiItems()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $client = $ninja->vendors->create(['name' => 'Brand spanking new client']);
 
@@ -149,8 +146,8 @@ class PurchaseOrdersTest extends TestCase
     public function testPurchaseOrderPostWithMultiItemsMarkSent()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $client = $ninja->vendors->create(['name' => 'Brand spanking new client']);
 
@@ -184,8 +181,8 @@ class PurchaseOrdersTest extends TestCase
     public function testDownloadPurchaseOrder()
     {
 
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $client = $ninja->vendors->create(['name' => 'Brand spanking new client']);
 

--- a/tests/QuotesTest.php
+++ b/tests/QuotesTest.php
@@ -16,14 +16,14 @@ use PHPUnit\Framework\TestCase;
 
 class QuotesTest extends TestCase
 {
-    protected string $token = "company-token-test";
-    protected string $url = "http://ninja.test:8000";
+
+
 
     public function testQuotes()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $quotes = $ninja->quotes->all();
 
@@ -34,8 +34,8 @@ class QuotesTest extends TestCase
     public function testQuoteGet()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $client = $ninja->clients->create(['name' => 'Brand spanking new client']);
         $quote = $ninja->quotes->create(['client_id' => $client['data']['id']]);
@@ -50,8 +50,8 @@ class QuotesTest extends TestCase
     public function testQuotePut()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
 
         $client = $ninja->clients->create(['name' => 'Brand spanking new client']);
@@ -67,8 +67,8 @@ class QuotesTest extends TestCase
     public function testQuotePost()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
         $client = $ninja->clients->create(['name' => 'Brand spanking new client']);
 
         $quotes = $ninja->quotes->create(['client_id' => $client['data']['id']]);

--- a/tests/RecurringInvoicesTest.php
+++ b/tests/RecurringInvoicesTest.php
@@ -16,14 +16,11 @@ use PHPUnit\Framework\TestCase;
 
 class RecurringInvoicesTest extends TestCase
 {
-    protected string $token = "company-token-test";
-    protected string $url = "http://ninja.test:8000";
-
     public function testInvoices()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $client = $ninja->clients->create(['name' => 'Brand spanking new client']);
 
@@ -38,8 +35,8 @@ class RecurringInvoicesTest extends TestCase
     public function testInvoiceGet()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $client = $ninja->clients->create(['name' => 'Brand spanking new client']);
 
@@ -55,8 +52,8 @@ class RecurringInvoicesTest extends TestCase
     public function testInvoicePut()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $client = $ninja->clients->create(['name' => 'Brand spanking new client']);
 
@@ -72,8 +69,8 @@ class RecurringInvoicesTest extends TestCase
     public function testInvoicePost()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $client = $ninja->clients->create(['name' => 'Brand spanking new client']);
         $invoices = $ninja->recurring_invoices->create(['frequency_id'=>1,'client_id' => $client['data']['id']]);

--- a/tests/StaticsTest.php
+++ b/tests/StaticsTest.php
@@ -17,14 +17,11 @@ use PHPUnit\Framework\TestCase;
 class StaticsTest extends TestCase
 {
 
-    protected string $token = "company-token-test";
-    protected string $url = "http://ninja.test:8000";
-
     public function testGetCurrencies()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $currencies = $ninja->statics->currencies();
 

--- a/tests/SubscriptionsTest.php
+++ b/tests/SubscriptionsTest.php
@@ -16,9 +16,6 @@ use PHPUnit\Framework\TestCase;
 
 class SubscriptionsTest extends TestCase
 {
-    protected string $token = "company-token-test";
-    protected string $url = "http://ninja.test:8000";
-
 
 
     public function setUp() :void
@@ -29,8 +26,8 @@ class SubscriptionsTest extends TestCase
 
     public function testSubscriptions()
     {
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $subscriptions = $ninja->subscriptions->create(['name' => $this->faker->firstName]);
         
@@ -41,15 +38,15 @@ class SubscriptionsTest extends TestCase
     public function testSubscriptionGet()
     {
     
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $subscription = $ninja->subscriptions->create(['name' => $this->faker->firstName]);
         
         $this->assertTrue(is_array($subscription));
 
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $subscriptions = $ninja->subscriptions->get($subscription['data']['id']);
 
@@ -61,8 +58,8 @@ class SubscriptionsTest extends TestCase
     public function testSubscriptionPut()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $subscription = $ninja->subscriptions->create(['name' => $this->faker->firstName]);
 
@@ -76,8 +73,8 @@ class SubscriptionsTest extends TestCase
     public function testSubscriptionPost()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $subscriptions = $ninja->subscriptions->create(['name' => $this->faker->firstName]);
         

--- a/tests/TasksTest.php
+++ b/tests/TasksTest.php
@@ -16,14 +16,14 @@ use PHPUnit\Framework\TestCase;
 
 class TasksTest extends TestCase
 {
-    protected string $token = "company-token-test";
-    protected string $url = "http://ninja.test:8000";
+
+
 
     public function testTasks()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $taks = $ninja->tasks->all();
 
@@ -34,8 +34,8 @@ class TasksTest extends TestCase
     public function testTaskGet()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $client = $ninja->clients->create(['name' => 'Brand spanking new client']);
         $task = $ninja->tasks->create(['name' => 'Project', 'client_id' => $client['data']['id']]);
@@ -50,8 +50,8 @@ class TasksTest extends TestCase
     public function testTaskPut()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $client = $ninja->clients->create(['name' => 'Brand spanking new client']);
         $task = $ninja->tasks->create(['name' => 'Project', 'client_id' => $client['data']['id']]);
@@ -66,8 +66,8 @@ class TasksTest extends TestCase
     public function testTaskPost()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $client = $ninja->clients->create(['name' => 'Brand spanking new client']);
         $taks = $ninja->tasks->create(['name' => 'Project', 'client_id' => $client['data']['id']]);        

--- a/tests/TasksTest.php
+++ b/tests/TasksTest.php
@@ -17,8 +17,6 @@ use PHPUnit\Framework\TestCase;
 class TasksTest extends TestCase
 {
 
-
-
     public function testTasks()
     {
         

--- a/tests/TaxRatesTest.php
+++ b/tests/TaxRatesTest.php
@@ -16,9 +16,6 @@ use PHPUnit\Framework\TestCase;
 
 class TaxRatesTest extends TestCase
 {
-    protected string $token = "company-token-test";
-    protected string $url = "http://ninja.test:8000";
-
     public $faker;
 
     protected function setUp(): void
@@ -29,8 +26,8 @@ class TaxRatesTest extends TestCase
     public function testProducts()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $tax_rates = $ninja->tax_rates->all();
 
@@ -41,8 +38,8 @@ class TaxRatesTest extends TestCase
     public function testTaxRateGet()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $tax_rate = $ninja->tax_rates->create(['rate' => 10, 'name' => $this->faker->word()]);
 
@@ -56,8 +53,8 @@ class TaxRatesTest extends TestCase
     public function testTaxRatePut()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $tax_rate = $ninja->tax_rates->create(['rate' => 10, 'name' => 'GSTa']);
 
@@ -71,8 +68,8 @@ class TaxRatesTest extends TestCase
     public function testTaxRatePost()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $tax_rates = $ninja->tax_rates->create(['rate' => 10, 'name' => $this->faker->word()]);
         

--- a/tests/VendorsTest.php
+++ b/tests/VendorsTest.php
@@ -16,13 +16,10 @@ use PHPUnit\Framework\TestCase;
 
 class VendorsTest extends TestCase
 {
-    protected string $token = "company-token-test";
-    protected string $url = "http://ninja.test:8000";
-
     public function testVendors()
     {
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $vendors = $ninja->vendors->create(['name' => 'Brand spanking new vendor']);
         
@@ -37,15 +34,15 @@ class VendorsTest extends TestCase
     public function testVendorGet()
     {
     
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $vendor = $ninja->vendors->create(['name' => 'Brand spanking new vendor']);
         
         $this->assertTrue(is_array($vendor));
 
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $vendors = $ninja->vendors->get($vendor['data']['id']);
 
@@ -57,8 +54,8 @@ class VendorsTest extends TestCase
     public function testVendorPut()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $vendor = $ninja->vendors->create(['name' => 'Brand spanking new vendor']);
 
@@ -72,8 +69,8 @@ class VendorsTest extends TestCase
     public function testVendorPost()
     {
         
-        $ninja = new InvoiceNinja($this->token);
-        $ninja->setUrl($this->url);
+        $ninja = new InvoiceNinja($_ENV['INVOICENINJA_TOKEN']);
+        $ninja->setUrl($_ENV['INVOICENINJA_URL']);
 
         $vendors = $ninja->vendors->create(['name' => 'Brand spanking new vendor']);
         


### PR DESCRIPTION
Refactor tests to use phpunit.xml env variables for invoiceninja url & token.

Makes it easier for other contributors to execute these tests (no need for search & replace across the all repo files to test locally).

In the current setup I have to modify these $token and $url properties for a test file, run the test, and then change it back in order to submit a PR with contributions.
