### PR TITLE
Fix exception thrown when JSON can't be decoded.

### DIFF
--- a/src/Exceptions/ApiException.php
+++ b/src/Exceptions/ApiException.php
@@ -34,6 +34,10 @@ class ApiException extends \Exception
         $object = @json_decode($body);
         $error_array = [];
 
+        if (!$object) {
+            throw new self("Unable to decode response: '{$body}'.");
+        }
+
         if(property_exists($object, "message"))
             $error = $object->message;
 
@@ -47,10 +51,6 @@ class ApiException extends \Exception
             if(is_array($error_array) && count($error_array) >=1)
                 $error = $error_array[0];
 
-        }
-
-        if (json_last_error() !== JSON_ERROR_NONE) {
-            throw new self("Unable to decode response: '{$body}'.");
         }
 
         return $error;


### PR DESCRIPTION
It currently crashes with a `TypeError` when using `property_exists($object, "...")` because `$object` is `null` if the JSON can't be decoded:

```

TypeError
vendor/invoiceninja/sdk-php/src/Exceptions/ApiException.php:37

property_exists(): Argument #1 ($object_or_class) must be of type object|string, null given


Stack trace:

InvoiceNinja\Sdk\Exceptions\ApiException property_exists()

vendor/invoiceninja/sdk-php/src/Exceptions/ApiException.php:37

InvoiceNinja\Sdk\Exceptions\ApiException::parseResponseBody()

vendor/invoiceninja/sdk-php/src/Exceptions/ApiException.php:37

InvoiceNinja\Sdk\Exceptions\ApiException::createFromResponse()

vendor/invoiceninja/sdk-php/src/Exceptions/ApiException.php:19


```